### PR TITLE
[ADD] account: add charge note to the core of odoo

### DIFF
--- a/addons/website/static/src/scss/compatibility/bs3_for_12_0.scss
+++ b/addons/website/static/src/scss/compatibility/bs3_for_12_0.scss
@@ -212,9 +212,13 @@ $-compat-breakpoints: (
 .hide {
     display: none !important;
 }
-.show {
-    display: block !important;
-}
+// The 'show' class could be supported if defined here and like that,
+// unfortunately, BS4 still defines a 'show' class for other purposes which
+// conflict with this (tab-pane, fade effects, ...). Adding more complex rules
+// won't solve the problem as they would change css rules priorities.
+// .show {
+//     display: block !important;
+// }
 .hidden {
     display: none !important;
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Peru, we use charge notes in order to create an special charge for the other partner to pay for extra costs from a service/product sale. Usually, in other countries you create another invoice, but in peru it's recommended to create debit note when you need to charge extra to a user.

With this change we add this way, it's just an addition to the credit wizard.

Current behavior before PR:
We don't have a charge note

Desired behavior after PR is merged:
We will have a charge note



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
