### PR TITLE
[FIX] base: fix wron currency label for peru

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -1462,7 +1462,7 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Inti</field>
+            <field name="currency_unit_label">Sol</field>
             <field name="currency_subunit_label">Centimes</field>
         </record>
 


### PR DESCRIPTION
Just fixing the label of peru, we need this fix


https://www.ibm.com/support/knowledgecenter/en/SSZLC2_7.0.0/com.ibm.commerce.payments.developer.doc/refs/rpylerl2mst97.htm

https://www.iban.com/currency-codes

https://en.wikipedia.org/wiki/ISO_4217

It's usually called peruvian sol, new peruvian sol, but the simple name can be Sol

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
