### PR TITLE
[REF] base: raise error instead delete records in partner merging

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -169,11 +169,12 @@ class MergePartnerAutomatic(models.TransientModel):
                             """
                             self._cr.execute(query, (dst_partner.id,))
                             # NOTE JEM : shouldn't we fetch the data ?
-                except psycopg2.Error:
+                except psycopg2.Error as e:
                     # updating fails, most likely due to a violated unique constraint
                     # keeping record with nonexistent partner_id is useless, better delete it
-                    query = 'DELETE FROM "%(table)s" WHERE "%(column)s" IN %%s' % query_dic
-                    self._cr.execute(query, (tuple(src_partners.ids),))
+                    msg="""An error has ocurred meanwhile foreign keys were updated \n Destination Record: %s \nSource Record: %s, \nError: %s""" % (dst_partner.id, tuple(src_partners.ids), e)
+                    _logger.error(msg)
+                    raise UserError(msg)
 
         self.invalidate_cache()
 
@@ -194,10 +195,12 @@ class MergePartnerAutomatic(models.TransientModel):
                 with mute_logger('odoo.sql_db'), self._cr.savepoint(), self.env.clear_upon_failure():
                     records.sudo().write({field_id: dst_partner.id})
                     records.flush()
-            except psycopg2.Error:
+            except psycopg2.Error as e:
                 # updating fails, most likely due to a violated unique constraint
                 # keeping record with nonexistent partner_id is useless, better delete it
-                records.sudo().unlink()
+                msg="""An error has ocurred meanwhile reference fields were updated \n Destination Record: %s \nSource Record: %s, \nError: %s""" % (dst_partner.id, tuple(src_partners.ids), e)
+                _logger.error(msg)
+                raise UserError(msg)
 
         update_records = functools.partial(update_records)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When an error in certain steps of the merging of partners is raised, deletion of records related is executed, then we will have concurrency errors because the backend users use the system for everything related to partners, and deletion of the records related is not an option because we are not deleting the partners either.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
